### PR TITLE
Fix converting fonts wider than one byte

### DIFF
--- a/FontToBytes/FixedConverter.swift
+++ b/FontToBytes/FixedConverter.swift
@@ -141,18 +141,19 @@ class FixedConverter: ModeConverter {
                     while remainingBits > 0 {
                         var byte: UInt8 = 0
                         let bitCount = min(remainingBits, 8)
+                        var mask: UInt8 = 1<<7
                         for bit in 0..<bitCount {
-                            byte <<= 1
                             switch self.direction {
                             case .topDown:
                                 if inputImage.isPixelSet(x: x*width+bit+8*byteIndex, y: y*height+row) {
-                                    byte |= 1
+                                    byte |= mask
                                 }
                             case .leftRight:
                                 if inputImage.isPixelSet(x: x*height+row, y: y*width+bit+8*byteIndex) {
-                                    byte |= 1
+                                    byte |= mask
                                 }
                             }
+                            mask >>= 1
                             remainingBits -= 1
                         }
                         byteWriter.writeByte(byte)


### PR DESCRIPTION
Hey, I needed to convert some more fonts today and I noticed that the converter is broken... 
I couldn't (or didn't enough have time to) nail down the problem, but this code fixes it.

I already had it in my repo when writing my own converters, but I ended up removing it because from my testing (at that time) it seemed that it wasn't needed. It turns out I got the testing wrong...

The fix is just a little more straightforward way of writing byte bit by bit, and it perhaps doesn't skip over some edge cases like the existing code :)

Thanks!